### PR TITLE
Fix early process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ Operating as: server
   - Quit
 ```
 
-If the printer does not show in the list:
+If the printer does not show in the list, make sure:
 
-- make sure the printer is turned on
-- make sure you did not connect to the printer using the system dialog
-- don't run two scripts attempting to access the printer at the same time
+- the printer is turned on
+- the printer is not currently charging
+- you did not connect to the printer using the system dialog
+- you aren't running more than one script at the same time
 
 If you know the name of the printer you want to connect to, pass its name to skip the menu:
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,4 +1,3 @@
-import Fs from 'fs'
 import { log } from './services/utils.js'
 import { print } from './services/print.js'
 
@@ -15,7 +14,10 @@ export async function printer (characteristic, file, options) {
   log('Starting printer...')
   try {
     await print(characteristic, target, options)
-    process.exit(0)
+    log('(Hit Ctrl+C to exit)')
+    // even though the printer write command completes, the printer
+    // is still printing, so the terminal process cannot be exited
+    // process.exit(0)
   }
   catch (err) {
     console.log(err)

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -42,12 +42,13 @@ export async function print (characteristic, file, options) {
     const { data, metadata } = await prepareData(image)
 
     // print
+    // @see https://github.com/davestewart/phomemo-cli/pull/6
     if (characteristic) {
       log(`Printing image "${file}" ...`)
       characteristic.write(data, true)
     }
 
-    // return
+    // resolve
     resolve(metadata)
   })
 }


### PR DESCRIPTION
The last PR introduced `process.exit()` for the `print` process, but it seems that the terminal needs to keep running for the print to complete.

Unfortunately, even with calling `writeAsync()` or `characteristic.notify()` the printer does not correctly report when it is _actually_ finished:

```ts
// subscribe to notifications
characteristic.subscribe()
characteristic.on('notify', (state) => {
  // notify fires only once, and state is always `false`
})

// print
const result = await characteristic.writeAsync(data, false)

// report
console.lof('done') // printer still printing
```

The only solution appears to be just to not exit the process.